### PR TITLE
Add settings page and zustand user store

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
-  "extends": [
-    "next/core-web-vitals",
-    "next/typescript"
-  ]
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off"
+  }
 }

--- a/app/account-creation/page.tsx
+++ b/app/account-creation/page.tsx
@@ -182,7 +182,7 @@ export default function AccountCreationPage() {
       setTimeout(() => {
         router.push("/dashboard");
       }, 2000);
-    } catch (error: any) {  // eslint-disable-line @typescript-eslint/no-explicit-any
+    } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
       console.error("Error creating account:", error);
       setErrorMessage(error.message || "Failed to create account");
     }
@@ -202,8 +202,9 @@ export default function AccountCreationPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/20 to-accent/20 animate-gradient-x p-8">
-      <div className="max-w-4xl mx-auto">
+    <div className="relative min-h-screen">
+      <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-secondary/20 to-accent/20 animate-gradient-x -z-10"></div>
+      <div className="relative max-w-4xl min-h-screen mx-auto p-8 bg-white shadow-lg">
         {successMessage && (
           <Alert variant="default" className="mb-4">
             <CheckCircledIcon className="h-4 w-4" />

--- a/app/api/update-user/route.ts
+++ b/app/api/update-user/route.ts
@@ -57,8 +57,9 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({ message: 'User updated successfully', data }, { status: 200 });
-  } catch (error: any) {
-        console.error('Error updating user:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  } catch (error: unknown) {
+    const errorMessage =
+    error instanceof Error ? error.message : 'An unknown error occurred';
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }

--- a/app/api/update-user/route.ts
+++ b/app/api/update-user/route.ts
@@ -1,0 +1,64 @@
+// app/api/update-user/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+import { z } from 'zod';
+
+const userSchema = z.object({
+    userId: z.string(),
+    username: z
+      .string()
+      .min(1, { message: "Name is required" })
+      .max(50, { message: "Name must be 50 characters or less" }),
+    birthday: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, {
+      message: "Please enter a valid date in YYYY-MM-DD format",
+    }),
+    sportInterests: z
+      .array(z.string())
+      .min(1, { message: "Please select at least one sport" }),
+    city: z.string().min(1, { message: "Please select a city" }),
+    profilePicture: z
+      .string()
+      .url({ message: "Please upload a profile picture" })
+      .optional(),
+  });
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const body = await request.json();
+
+    const parsedData = userSchema.safeParse(body);
+
+    if (!parsedData.success) {
+      const errors = parsedData.error.errors.map((err) => ({
+        field: err.path.join('.'),
+        message: err.message,
+      }));
+      return NextResponse.json({ errors }, { status: 400 });
+    }
+
+    const { userId, ...updateData } = parsedData.data;
+
+    const { data, error } = await supabase
+      .from('users')
+      .update({
+        username: updateData.username,
+        birthday: updateData.birthday,
+        sport_interests: updateData.sportInterests,
+        city: updateData.city,
+        profile_picture_url: updateData.profilePicture || null,
+      })
+      .eq('id', userId)
+      .select();
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({ message: 'User updated successfully', data }, { status: 200 });
+  } catch (error: any) {
+        console.error('Error updating user:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/dashboard/dasboard-client.tsx
+++ b/app/dashboard/dasboard-client.tsx
@@ -1,50 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Buddy } from "@/types";
+import { useUserStore } from "@/store/userStore";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import TmpClientComponent from "../app/TmpClientComponent/TmpClientComponent";
-import { logout } from "../app/logout/action";
+import TmpClientComponent from "../TmpClientComponent/TmpClientComponent";
+import { logout } from "../logout/action";
 import Link from "next/link";
 
-interface DashboardProps {
-  userId: string;
-}
+export default function DashboardComponent() {
+  const user = useUserStore((state) => state.user);
+  console.log("dashboard user", user?.username);
 
-export default function DashboardComponent({ userId }: DashboardProps) {
-  const [user, setUser] = useState<Buddy | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  // Fetch user data in the browser (client side) using the userId
-  useEffect(() => {
-    async function fetchUser() {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/get-user?id=${userId}`, {
-          cache: "no-store",
-        });
-        const data: Buddy = await res.json();
-        setUser(data);
-      } catch (err) {
-        console.error("Failed to fetch user:", err);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchUser();
-  }, [userId]);
-
-  // Show a loading state while fetching
-  if (loading) {
-    return <p className="m-4">Loading user data...</p>;
-  }
-
-  // If there's no user data returned
-  if (!user) {
-    return <p className="m-4">No user found.</p>;
-  }
 
   return (
     <div className="container mx-auto p-6">
@@ -52,7 +18,7 @@ export default function DashboardComponent({ userId }: DashboardProps) {
 
       <div className="flex justify-between items-center mb-6">
         <TmpClientComponent />
-        <h2 className="text-3xl font-bold">Hello {user.username}</h2>
+        <h2 className="text-3xl font-bold">Hello {user?.username}</h2>
 
         <form action={logout}>
           <Button type="submit">Logout</Button>
@@ -61,7 +27,7 @@ export default function DashboardComponent({ userId }: DashboardProps) {
 
       {/* Quick Actions */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-      <Link href="/match-creation">
+        <Link href="/match-creation">
           <Button className="h-20 w-full">Create Event</Button>
         </Link>
         <Button variant="outline" className="h-20">

--- a/app/dashboard/dasboard-client.tsx
+++ b/app/dashboard/dasboard-client.tsx
@@ -6,11 +6,20 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import TmpClientComponent from "../TmpClientComponent/TmpClientComponent";
 import { logout } from "../logout/action";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export default function DashboardComponent() {
+  const router = useRouter();
   const user = useUserStore((state) => state.user);
-  console.log("dashboard user", user?.username);
+  const clearUser = useUserStore((state) => state.clearUser);
 
+  const handleLogout = async () => {
+    const result = await logout();
+    if (result?.success) {
+      clearUser();
+      router.push("/");
+    }
+  };
 
   return (
     <div className="container mx-auto p-6">
@@ -20,9 +29,7 @@ export default function DashboardComponent() {
         <TmpClientComponent />
         <h2 className="text-3xl font-bold">Hello {user?.username}</h2>
 
-        <form action={logout}>
-          <Button type="submit">Logout</Button>
-        </form>
+        <Button onClick={handleLogout}>Logout</Button>
       </div>
 
       {/* Quick Actions */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,70 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+ 
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+ 
+    --primary: 81 89% 61%;
+    --primary-foreground: 200 20% 12%;
+ 
+    --secondary: 104 35% 60%;
+    --secondary-foreground: 0 0% 0%;
+ 
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+ 
+    --accent: 81 89% 61%;
+    --accent-foreground: 200 20% 12%;
+ 
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+ 
+    --radius: 0.5rem;
+  }
+ 
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+ 
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+ 
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+ 
+    --primary: 81 89% 61%;
+    --primary-foreground: 200 20% 12%;
+ 
+    --secondary: 104 35% 60%;
+    --secondary-foreground: 0 0% 0%;
+ 
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+ 
+    --accent: 81 89% 61%;
+    --accent-foreground: 200 20% 12%;
+ 
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+ 
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+}
+
 @layer utilities {
   .animate-gradient-x {
     background-size: 200% 200%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { UserProvider } from "@/components/user-provider";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <UserProvider>{children}</UserProvider>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Toaster } from "@/components/ui/toaster"
 import localFont from "next/font/local";
 import "./globals.css";
 import { UserProvider } from "@/components/user-provider";
@@ -27,6 +28,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <UserProvider>{children}</UserProvider>
+        <Toaster />
       </body>
     </html>
   );

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -15,7 +15,12 @@ const loginSchema = z.object({
 const signupSchema = z.object({
   name: z.string().min(1).max(50),
   email: z.string().email(),
-  password: z.string().min(8).regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/),
+  password: z
+    .string()
+    .min(8)
+    .regex(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/
+    ),
 });
 
 export async function login(data: z.infer<typeof loginSchema>) {
@@ -40,7 +45,7 @@ export async function login(data: z.infer<typeof loginSchema>) {
   }
 
   revalidatePath("/", "layout");
-  redirect("/dashboard");
+  return { loginSuccess: true };
 }
 
 export async function signup(data: z.infer<typeof signupSchema>) {
@@ -73,9 +78,8 @@ export async function signup(data: z.infer<typeof signupSchema>) {
     throw new Error("Failed to fetch user data");
   }
 
-  console.log("User data:", userData);
   revalidatePath("/", "layout");
-  redirect("/account-creation");
+  return { signupSuccess: true };
 }
 
 export async function signInWithOAuth(provider: Provider) {
@@ -97,4 +101,3 @@ export async function signInWithOAuth(provider: Provider) {
 
   redirect(data.url);
 }
-

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { login, signup, signInWithOAuth } from "./actions";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -23,6 +24,8 @@ import {
   ExclamationTriangleIcon,
 } from "@radix-ui/react-icons";
 import { Spinner } from "@/components/ui/spinner"; // Importiere den Spinner
+import { useRouter } from "next/navigation";
+import { useUserStore } from "@/store/userStore";
 
 // Zod Schema Definition
 const formSchemaLogin = z.object({
@@ -61,6 +64,8 @@ export default function LoginPage() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false); // Neuer State für das Laden
+  const router = useRouter();
+  const fetchUser = useUserStore((state) => state.fetchUser);
 
   const form = useForm<
     z.infer<typeof formSchemaLogin> | z.infer<typeof formSchemaSignup>
@@ -84,10 +89,16 @@ export default function LoginPage() {
     setErrorMessage(null);
     try {
       if (mode === "login") {
-        await login(data as z.infer<typeof formSchemaLogin>);
-        setSuccessMessage("Logged in successfully!");
+        const response = await login(data as z.infer<typeof formSchemaLogin>);
+        if (response?.loginSuccess) {
+          await fetchUser();
+          router.push("/dashboard");
+        }
       } else {
-        await signup(data as z.infer<typeof formSchemaSignup>);
+        const response = await signup(data as z.infer<typeof formSchemaSignup>);
+        if (response?.signupSuccess) {
+          router.push("/account-creation");
+        }
         setSuccessMessage("Account created successfully!");
       }
     } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -188,7 +199,7 @@ export default function LoginPage() {
                     />
                     <Button
                       type="submit"
-                      disabled={isLoading} 
+                      disabled={isLoading}
                       className="w-full bg-primary text-primary-foreground hover:bg-primary/90 text-lg px-6 py-3 rounded-full flex items-center justify-center"
                     >
                       {isLoading ? (
@@ -196,8 +207,10 @@ export default function LoginPage() {
                           <Spinner />
                           {mode === "login" ? "Logging in..." : "Signing up..."}
                         </>
+                      ) : mode === "login" ? (
+                        "Login"
                       ) : (
-                        (mode === "login" ? "Login" : "Sign Up")
+                        "Sign Up"
                       )}
                     </Button>
                   </form>
@@ -301,8 +314,10 @@ export default function LoginPage() {
                           <Spinner />
                           {mode === "signup" ? "Signing up..." : "Login..."}
                         </>
+                      ) : mode === "signup" ? (
+                        "Sign Up"
                       ) : (
-                        (mode === "signup" ? "Sign Up" : "Login")
+                        "Login"
                       )}
                     </Button>
                   </form>
@@ -315,7 +330,7 @@ export default function LoginPage() {
               variant="outline"
               className="w-full border-primary text-primary hover:bg-primary/10 text-lg px-6 py-3 rounded-full flex items-center justify-center"
               onClick={() => signInWithOAuth("google")}
-              disabled={isLoading} 
+              disabled={isLoading}
             >
               {isLoading ? (
                 <>

--- a/app/logout/action.ts
+++ b/app/logout/action.ts
@@ -1,19 +1,17 @@
-'use server'
+"use server";
 
-import { revalidatePath } from 'next/cache'
-import { redirect } from 'next/navigation'
+import { redirect } from "next/navigation";
 
-import { createClient } from '@/utils/supabase/server'
+import { createClient } from "@/utils/supabase/server";
 
 export async function logout() {
-    const supabase = await createClient()
+  const supabase = await createClient();
 
-    const { error } = await supabase.auth.signOut();
+  const { error } = await supabase.auth.signOut();
 
-    if (error) {
-        redirect('/error')
-    }
+  if (error) {
+    redirect("/error");
+  }
 
-    revalidatePath('/', 'layout')
-    redirect('/')
+  return { success: true };
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,8 +1,8 @@
+import SettingsClient from "./settings-client";
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
-import DashboardComponent from "./dasboard-client";
 
-export default async function DashboardPage() {
+export default async function SettingsPage() {
   const supabase = await createClient();
 
   // Check if user is logged in
@@ -10,6 +10,5 @@ export default async function DashboardPage() {
   if (error || !data?.user) {
     redirect("/login");
   }
-
-  return <DashboardComponent />;
+  return <SettingsClient />;
 }

--- a/app/settings/settings-client.tsx
+++ b/app/settings/settings-client.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { FaUser, FaBell, FaQuestionCircle, FaUserPlus } from "react-icons/fa";
+import { useUserStore } from "@/store/userStore";
+import { Buddy } from "@/types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const settingsSections = [
+  { id: "account", title: "Account", icon: FaUser },
+  { id: "notifications", title: "Notifications", icon: FaBell },
+  { id: "help", title: "Help Center", icon: FaQuestionCircle },
+  { id: "invite", title: "Invite Friends", icon: FaUserPlus },
+];
+
+const sports = [
+  "Soccer",
+  "Basketball",
+  "Tennis",
+  "Volleyball",
+  "Swimming",
+  "Cycling",
+  "Running",
+  "Badminton",
+  "Table Tennis",
+  "Hiking",
+];
+
+const germanCities = [
+  "Berlin",
+  "Hamburg",
+  "Munich",
+  "Cologne",
+  "Frankfurt",
+  "Stuttgart",
+  "Düsseldorf",
+  "Leipzig",
+  "Dortmund",
+  "Essen",
+];
+
+export default function SettingsPage() {
+  const [activeSection, setActiveSection] = useState("account");
+  const [isEditing, setIsEditing] = useState(false);
+  const user = useUserStore((state) => state.user);
+
+  const renderSectionContent = () => {
+    switch (activeSection) {
+      case "account":
+        return (
+          user && (
+            <AccountSettings
+              user={user}
+              isEditing={isEditing}
+              setIsEditing={setIsEditing}
+            />
+          )
+        );
+      case "notifications":
+        return <NotificationSettings />;
+      case "help":
+        return <HelpCenter />;
+      case "invite":
+        return <InviteFriends />;
+      default:
+        return null;
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        User not found.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-primary/20 via-secondary/20 to-accent/20 animate-gradient-x p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl font-bold text-center text-text-primary mb-8">
+          Settings
+        </h1>
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <div className="flex items-center space-x-4">
+                <Avatar className="w-16 h-16 border-2 border-primary">
+                  <AvatarImage
+                    src={user.profile_picture_url || "/placeholder-avatar.jpg"}
+                    alt="Profile picture"
+                  />
+                  <AvatarFallback>{user.username.charAt(0)}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <h2 className="text-2xl font-semibold">{user.username}</h2>
+                  <p className="text-muted-foreground">{user.email}</p>
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() => setIsEditing(!isEditing)}
+              >
+                {isEditing ? "Save Changes" : "Edit Profile"}
+              </Button>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-6">
+            <div className="flex flex-col md:flex-row gap-6">
+              <div className="w-full md:w-1/3 space-y-2">
+                {settingsSections.map((section) => (
+                  <Button
+                    key={section.id}
+                    variant={activeSection === section.id ? "default" : "ghost"}
+                    className="w-full justify-start text-left"
+                    onClick={() => setActiveSection(section.id)}
+                  >
+                    <section.icon className="mr-2 h-4 w-4" />
+                    {section.title}
+                  </Button>
+                ))}
+              </div>
+              <div className="w-full md:w-2/3">
+                <AnimatePresence mode="wait">
+                  <motion.div
+                    key={activeSection}
+                    initial={{ opacity: 0, x: 20 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    exit={{ opacity: 0, x: -20 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    {renderSectionContent()}
+                  </motion.div>
+                </AnimatePresence>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function AccountSettings({
+  user,
+  isEditing,
+  setIsEditing,
+}: {
+  user: Buddy;
+  isEditing: boolean;
+  setIsEditing: (value: boolean) => void;
+}) {
+  const [formData, setFormData] = useState(user);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSelectChange = (name: string, value: string) => {
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSportToggle = (sport: string) => {
+    const updatedSports = formData.sport_interests.includes(sport)
+      ? formData.sport_interests.filter((s) => s !== sport)
+      : [...formData.sport_interests, sport];
+    setFormData({ ...formData, sport_interests: updatedSports });
+  };
+
+  const handleSubmit = async () => {
+    // Implement the API call to update user data
+    console.log("Updating user data:", formData);
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold mb-4">Account Settings</h3>
+      <div className="space-y-2">
+        <Label htmlFor="username">Username</Label>
+        <Input
+          id="username"
+          name="username"
+          value={formData.username}
+          onChange={handleInputChange}
+          readOnly={!isEditing}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="birthday">Birthday</Label>
+        <Input
+          id="birthday"
+          name="birthday"
+          type="date"
+          value={formData.birthday}
+          onChange={handleInputChange}
+          readOnly={!isEditing}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>City</Label>
+        <Select
+          value={formData.city}
+          onValueChange={(value) => handleSelectChange("city", value)}
+          disabled={!isEditing}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select a city" />
+          </SelectTrigger>
+          <SelectContent>
+            {germanCities.map((city) => (
+              <SelectItem key={city} value={city}>
+                {city}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label>Sport Interests</Label>
+        <div className="grid grid-cols-2 gap-2">
+          {sports.map((sport) => (
+            <Button
+              key={sport}
+              variant={
+                formData.sport_interests.includes(sport) ? "default" : "outline"
+              }
+              onClick={() => handleSportToggle(sport)}
+              disabled={!isEditing}
+            >
+              {sport}
+            </Button>
+          ))}
+        </div>
+      </div>
+      {isEditing && (
+        <Button onClick={handleSubmit} className="mt-4">
+          Save Changes
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function NotificationSettings() {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold mb-4">Notification Settings</h3>
+      <div className="space-y-2">
+        <Label>Chat Notifications</Label>
+        <div className="flex items-center justify-between">
+          <span>Enable chat notifications</span>
+          <Switch />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label>Match Notifications</Label>
+        <div className="flex items-center justify-between">
+          <span>Enable match notifications</span>
+          <Switch />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label>Request Notifications</Label>
+        <div className="flex items-center justify-between">
+          <span>Enable request notifications</span>
+          <Switch />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HelpCenter() {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold mb-4">Help Center</h3>
+      <Button variant="outline" className="w-full justify-start">
+        FAQs
+      </Button>
+      <Button variant="outline" className="w-full justify-start">
+        Privacy Policy
+      </Button>
+      <Button variant="outline" className="w-full justify-start">
+        Terms of Service
+      </Button>
+      <Button variant="outline" className="w-full justify-start">
+        Contact Support
+      </Button>
+    </div>
+  );
+}
+
+function InviteFriends() {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold mb-4">Invite Friends</h3>
+      <p>Share this link with your friends to invite them to our app:</p>
+      <div className="flex space-x-2">
+        <Input value="https://example.com/invite/johndoe" readOnly />
+        <Button>Copy</Button>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import * as React from "react"
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const ToastProvider = ToastPrimitives.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitives.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold [&+div]:text-xs", className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useToast } from "@/hooks/use-toast"
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast"
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/components/user-provider.tsx
+++ b/components/user-provider.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useUserStore } from '@/store/userStore'
+
+export function UserProvider({ children }: { children: React.ReactNode }) {
+  const fetchUser = useUserStore(state => state.fetchUser)
+
+  useEffect(() => {
+    fetchUser()
+  }, [fetchUser])
+
+  return <>{children}</>
+}
+

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -1,0 +1,194 @@
+"use client"
+
+// Inspired by react-hot-toast library
+import * as React from "react"
+
+import type {
+  ToastActionElement,
+  ToastProps,
+} from "@/components/ui/toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.2",
+        "@radix-ui/react-toast": "^1.2.4",
         "@supabase/auth-ui-react": "^0.4.7",
         "@supabase/auth-ui-shared": "^0.1.8",
         "@supabase/ssr": "^0.5.2",
@@ -1553,6 +1554,39 @@
         "@radix-ui/react-primitive": "2.0.1",
         "@radix-ui/react-roving-focus": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.4.tgz",
+      "integrity": "sha512-Sch9idFJHJTMH9YNpxxESqABcAFweJG4tKv+0zo0m5XBvUSL8FM5xKcJLFLXononpePs8IclyX1KieL5SDUNgA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-radio-group": "^1.2.2",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.2",
         "@supabase/auth-ui-react": "^0.4.7",
         "@supabase/auth-ui-shared": "^0.1.8",
@@ -32,7 +33,8 @@
         "react-icons": "^5.4.0",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.24.1"
+        "zod": "^3.24.1",
+        "zustand": "^5.0.2"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1504,6 +1506,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.2.tgz",
+      "integrity": "sha512-zGukiWHjEdBCRyXvKR6iXAQG6qXm2esuAD6kDOi9Cn+1X6ev3ASo4+CsYaD6Fov9r/AQFekqnD/7+V0Cs6/98g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -6948,6 +6979,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.2.tgz",
+      "integrity": "sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-radio-group": "^1.2.2",
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.2",
     "@supabase/auth-ui-react": "^0.4.7",
     "@supabase/auth-ui-shared": "^0.1.8",
@@ -33,7 +34,8 @@
     "react-icons": "^5.4.0",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.2",
+    "@radix-ui/react-toast": "^1.2.4",
     "@supabase/auth-ui-react": "^0.4.7",
     "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/ssr": "^0.5.2",

--- a/store/userStore.ts
+++ b/store/userStore.ts
@@ -7,6 +7,7 @@ interface UserState {
   user: Buddy | null;
   fetchUser: () => Promise<void>;
   clearUser: () => void;
+  updateUser: (user: Partial<Buddy>) => void;
 }
 
 export const useUserStore = create(
@@ -53,6 +54,10 @@ export const useUserStore = create(
       clearUser: () => {
         set({ user: null });
       },
+      updateUser: (partialUser: Partial<Buddy>) => 
+        set((state) => ({
+          user: state.user ? { ...state.user, ...partialUser } : null,
+        })),
     }),
     {
       name: "user-storage",

--- a/store/userStore.ts
+++ b/store/userStore.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { createClient } from "@/utils/supabase/client";
+import { Buddy } from "@/types";
+
+interface UserState {
+  user: Buddy | null;
+  fetchUser: () => Promise<void>;
+}
+
+export const useUserStore = create(
+  persist<UserState>(
+    (set) => ({
+      user: null,
+      fetchUser: async () => {
+        const supabase = createClient();
+        const {
+          data: { user },
+          error,
+        } = await supabase.auth.getUser();
+
+        if (error || !user) {
+          set({ user: null });
+          return;
+        }
+
+        // Fetch additional user data (account-creation)
+        const { data: userData, error: userError } = await supabase
+          .from("users")
+          .select("*")
+          .eq("id", user.id)
+          .single();
+        if (userError) {
+          console.error("Error fetching user data:", userError);
+          set({ user: null });
+          return;
+        }
+
+        set({
+          user: {
+            ...userData,
+            id: user.id,
+            email: user.email,
+          },
+        });
+      },
+    }),
+    {
+      name: "user-storage",
+    }
+  )
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,12 +21,32 @@ export default {
           foreground: "hsl(var(--popover-foreground))",
         },
         primary: {
-          DEFAULT: "#BBF246", // Primary fill color
-          foreground: "#192126", // Primary text color
+          DEFAULT: "hsl(81, 89%, 61%)", // #BBF246
+          foreground: "hsl(200, 20%, 12%)", // #192126
+          "50": "hsl(81, 89%, 95%)",
+          "100": "hsl(81, 89%, 90%)",
+          "200": "hsl(81, 89%, 80%)",
+          "300": "hsl(81, 89%, 70%)",
+          "400": "hsl(81, 89%, 61%)", // #BBF246
+          "500": "hsl(81, 89%, 55%)",
+          "600": "hsl(81, 89%, 49%)",
+          "700": "hsl(81, 89%, 43%)",
+          "800": "hsl(81, 89%, 37%)",
+          "900": "hsl(81, 89%, 31%)",
         },
         secondary: {
-          DEFAULT: "#89C66D", // Secondary fill color
-          foreground: "#000000", // Secondary text color
+          DEFAULT: "hsl(104, 35%, 60%)", // #89C66D
+          foreground: "hsl(0, 0%, 0%)", // #000000
+          "50": "hsl(104, 35%, 95%)",
+          "100": "hsl(104, 35%, 90%)",
+          "200": "hsl(104, 35%, 80%)",
+          "300": "hsl(104, 35%, 70%)",
+          "400": "hsl(104, 35%, 60%)", // #89C66D
+          "500": "hsl(104, 35%, 50%)",
+          "600": "hsl(104, 35%, 40%)",
+          "700": "hsl(104, 35%, 30%)",
+          "800": "hsl(104, 35%, 20%)",
+          "900": "hsl(104, 35%, 10%)",
         },
         muted: {
           DEFAULT: "hsl(var(--muted))",
@@ -51,13 +71,8 @@ export default {
           "5": "hsl(var(--chart-5))",
         },
         text: {
-          primary: "#192126", // Primary text color
+          primary: "hsl(200, 20%, 12%)", // #192126
         },
-      },
-      borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
       },
     },
   },

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,10 +2,11 @@ export type Buddy = {
   id: string;
   name: string;
   updated_at: string;
+  email: string;
   username: string;
   birthday: string;
   gender_enum: "male" | "female" | "other" | "prefer-not-to-say";
-  sport_interest: string[];
+  sport_interests: string[];
   city: string;
-  profile_picture: string;
+  profile_picture_url: string;
 };

--- a/utils/supabase/storage.ts
+++ b/utils/supabase/storage.ts
@@ -24,5 +24,10 @@ export async function uploadProfilePicture(file: File): Promise<string | null> {
     .from('profile_pictures')
     .getPublicUrl(fileName);
 
-  return data.publicUrl;
+    if (!data || !data.publicUrl) return null;
+
+    const timestamp = new Date().getTime();
+    const publicUrlWithTimestamp = `${data.publicUrl}?t=${timestamp}`;
+  
+    return publicUrlWithTimestamp;
 }


### PR DESCRIPTION
Aside from the settings page i have modified our login workflow. Currently the settings page **does not communicate  with the backend yet.**

1. In our `layout.tsx` there is a user provider that wraps all the children. It initially fetches the user based on the user id once and stores it in local storage.
2. On log out local storage gets set to null again.

https://github.com/user-attachments/assets/b6646b88-3914-48b6-a729-e69c0ff586fe

